### PR TITLE
UV 2.8

### DIFF
--- a/universalVersion/deleteQuestion.php
+++ b/universalVersion/deleteQuestion.php
@@ -28,11 +28,19 @@ session_start(); //starts the session to store certain variables using cookies
 			}
 			$deleteMe = $_SESSION['questionID'];
 			//echo "<p>" .$deleteMe ."</p>"; 
-			$sql = "DELETE FROM questiondetails WHERE questionID = '$deleteMe'";
-			if($result = mysql_query($sql))
+			
+			$sql = "DELETE FROM responsedetails WHERE questionID = '$deleteMe'"; //first delete any associated responses 
+			
+			if ($result = mysql_query($sql))
+				{
+			
+					$sql = "DELETE FROM questiondetails WHERE questionID = '$deleteMe'";
+						if($result = mysql_query($sql))
 							{
 								header("location:forumMenu.php"); 
 							}
+				}
+				
 ?>
 
 </body>

--- a/universalVersion/profilePage.php
+++ b/universalVersion/profilePage.php
@@ -173,8 +173,13 @@ session_start(); //starts the session to store certain variables using cookies
 						
 						if ($stringCheck == "false")
 							{
-								echo "You have: neglected to fill out one of the fields, entered the wrong current password, or not changed the new password."; 
-							
+								//echo "You have: neglected to fill out one of the fields, entered the wrong current password, or not changed the new password."; 
+								?>
+									<script>if (window.confirm('You have neglected to fill out one of the fields, entered the wrong current password, or not entered a new different password. Retry?')) {
+											window.location.href='profilePage.php';
+											}
+						</script> <!--runs a script to redirect the user, asking if they want to log in right away -->
+						<?php
 							}
 						
 						
@@ -236,7 +241,7 @@ session_start(); //starts the session to store certain variables using cookies
 			foreach($variableArray as $title)
 					{
 						$relID = $idArray[$arrayCounter];
-						echo "<center><h2><a href='questionResponse.php?qid=$relID' id='questionTitle'>$title</a></h2></center>";
+						echo "<center><h2><a href='questionResponse.php?qid=$relID&id=1' id='questionTitle'>$title</a></h2></center>";
 						$arrayCounter = $arrayCounter + 1; 
 					} 
 		

--- a/universalVersion/questionResponse.php
+++ b/universalVersion/questionResponse.php
@@ -15,23 +15,11 @@ session_start(); //starts the session to store certain variables using cookies
 <body>
 <?php		
 		
-	if (isset($_GET['upvote'])) 
+	if (isset($_GET['vote'])) 
 		{
-				$_SESSION['vote']= 'Up';
 				header("location:voteChange.php"); 
 		}
 	
-	if (isset($_GET['downvote'])) 
-		{
-					$_SESSION['vote']= 'Down';
-					header("location:voteChange.php"); 
-		}
-	
-	if (isset($_GET['cancel'])) 
-		{
-					$_SESSION['vote']= 'Cancel';
-					header("location:voteChange.php"); 
-		}
 	
 	if (isset($_GET['delete']))
 		{
@@ -51,7 +39,7 @@ session_start(); //starts the session to store certain variables using cookies
 			}
 		
 		$questionID = $_GET['qid']; //gets the question ID from the previous page 
-		
+		$_SESSION['qid'] = $questionID; //for use with the voting page redirect 
 		
 		$dbcnx = @mysql_connect('localhost', 'root', 'cisgroup');
 	if (!$dbcnx) //if a connection cannot be made, the code will exit gracefully 
@@ -156,7 +144,7 @@ session_start(); //starts the session to store certain variables using cookies
 			$row = mysql_fetch_row($result);
 			$posterID = $row[0]; //assign the ID of the poster of the question to a variable
 		
-		$responseCategoryID = 1;  //for now the category is set to 1. 
+		
 		#show the section of the question 
 		$sectionQuery = "SELECT title FROM categories WHERE categoryID = '$responseCategoryID'";
 		$result = mysql_query($sectionQuery);
@@ -222,13 +210,13 @@ session_start(); //starts the session to store certain variables using cookies
 		
 		if ($sameUser == "false" && $answerCheck != 1 && $loggedIn == "true")
 		{
-		echo "<p id=questionTitle2>&#8593 <a href='questionResponse.php?upvote=true'>Up Vote</a> &nbsp; &#8595 <a href='questionResponse.php?downvote=true'>Down Vote</a> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Score: <big><b>$score</b></big>
+		echo "<p id=questionTitle2>&#8593 <a href='voteChange.php?vote=up'>Up Vote</a> &nbsp; &#8595 <a href='voteChange.php?vote=down'>Down Vote</a> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Score: <big><b>$score</b></big>
 		</p> ";
 		}
 
 		if ($answerCheck  != 0 && $loggedIn == "true")
 		{
-		echo "<p id=questionTitle2> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a href='questionResponse.php?cancel=true'>Cancel Vote</a>&nbsp;&nbsp;&nbsp;Score: <big><b>$score</b></big>
+		echo "<p id=questionTitle2> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a href='voteChange.php?vote=cancel'>Cancel Vote</a>&nbsp;&nbsp;&nbsp;Score: <big><b>$score</b></big>
 		</p> ";
 		}
 		
@@ -249,7 +237,7 @@ if(isset($_GET['id']))
 	$start=($id-1)*$limit;
 }
 //echo $id;
-$query=mysql_query("SELECT responseContent, responseDetails.userID, userNickname FROM responseDetails INNER JOIN userDetails ON responseDetails.userID = userDetails.userID WHERE questionID = $responseID LIMIT $start, $limit");
+$query=mysql_query("SELECT responseContent, responseDetails.userID, userNickname FROM responseDetails INNER JOIN userDetails ON responseDetails.userID = userDetails.userID WHERE questionID = $responseID ORDER BY responseID DESC LIMIT $start, $limit");
 
 	while($query2=mysql_fetch_array($query))
 		{

--- a/universalVersion/voteChange.php
+++ b/universalVersion/voteChange.php
@@ -35,23 +35,27 @@ session_start(); //starts the session to store certain variables using cookies
 					
 //change the score
 			$_SESSION['oldScore'] = 0; //initialise variable to hold the previous score of the question 
-
-			if ($_SESSION['vote'] == 'Up')
+			
+			$_SESSION['vote'] = $_GET['vote'];
+			$questionID = $_SESSION['questionID'];
+			$relID = $_SESSION['qid'];
+			
+			if ($_SESSION['vote'] == 'up')
 				{
 					$_SESSION['oldScore'] = $_SESSION['score']; //hold the old score in case the user wants to their up/down vote
 					$_SESSION['score'] = $_SESSION['score'] + 1; 
 					$_SESSION['currentScore'] = $_SESSION['score']; 
 					$newScore = $_SESSION['score'];
-					$questionID = $_SESSION['questionID'];
-				
+					
+					
 					$sql = "UPDATE questionDetails SET score = $newScore WHERE questionID = $questionID";
 						if($result = mysql_query($sql))
 							{
-								header("location:questionResponse.php"); 
+								header("location:questionResponse.php?qid=$relID&id=1"); 
 							}
 				} //end if
 			
-			if ($_SESSION['vote'] == 'Down')
+			if ($_SESSION['vote'] == 'down')
 				{
 					$_SESSION['oldScore'] = $_SESSION['score']; //hold the old score in case the user wants to their up/down vote
 					$_SESSION['score'] = $_SESSION['score'] - 1; 
@@ -62,10 +66,10 @@ session_start(); //starts the session to store certain variables using cookies
 					$sql = "UPDATE questionDetails SET score = $newScore WHERE questionID = $questionID";
 						if($result = mysql_query($sql))
 							{
-								header("location:questionResponse.php"); 
+								header("location:questionResponse.php?qid=$relID&id=1"); 
 							}
 				}
-			if ($_SESSION['vote'] == 'Cancel')
+			if ($_SESSION['vote'] == 'cancel')
 				{
 					$_SESSION['score'] = $_SESSION['oldScore']; 
 					$newScore = $_SESSION['score'];
@@ -74,7 +78,7 @@ session_start(); //starts the session to store certain variables using cookies
 					$sql = "UPDATE questionDetails SET score = $newScore WHERE questionID = $questionID";
 						if($result = mysql_query($sql))
 							{
-								header("location:questionResponse.php"); 
+								header("location:questionResponse.php?qid=$relID&id=1"); 
 							}
 			
 				} //end if


### PR DESCRIPTION
Error message when resetting password wrongly now disappears on the second try. The most recent comments to a question appear first. The query now deletes any responses related to a question before deleting that question, and the database copy has cascade on it (working master version). The links from the user's page to their question no longer causes an error. The downvote and upvote system should now work, and return the user to the original question page.
